### PR TITLE
Fix bug: User-uploaded bed9 can only be displayed in target

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,15 +151,18 @@
         <input type="file" id="uploader" />
       </label>
       <!-- Initialize a select button -->
-      <label class="custom-file-upload">
-        Load bed9 data for the target
-        <input type="file" id="uploaderbed" />
+      <div class="custom-file-upload">
+        <label>
+          Load bed9 data for the target
+          <input type="file" id="uploaderbed" />
+        </label>
         <br />
         <br />
-        Load bed9 data for the query
-        <input type="file" id="uploaderquerybed" />
-        <br />
-      </label>
+        <label>
+          Load bed9 data for the query
+          <input type="file" id="uploaderquerybed" />
+        </label>
+      </div>
      <!-- Initialize a select button -->
       <label class="custom-file-upload">
         Add <b>UCSC</b> snapshot


### PR DESCRIPTION
Hello Mitchell!

Thank you for developing such a useful tool!

I found that whether I clicked "Load bed9 data for the target" or "Load bed9 data for the query", the annotation would be displayed on the target. I fixed this issue.
